### PR TITLE
Add request id to errors

### DIFF
--- a/plaid/errors.py
+++ b/plaid/errors.py
@@ -1,10 +1,11 @@
 class PlaidError(Exception):
     retry = False
 
-    def __init__(self, message=None, code=None):
+    def __init__(self, message=None, code=None, request_id=None):
         self.code = code
         self.message = message
-        super(PlaidError, self).__init__(message)
+        self.request_id = request_id
+        super(PlaidError, self).__init__(message, request_id)
 
 
 class BadRequestError(PlaidError):

--- a/plaid/requester.py
+++ b/plaid/requester.py
@@ -15,7 +15,7 @@ def http_request(url, method=None, data=None, suppress_errors=False):
     ERROR = PLAID_ERROR_MAP.get(response.status_code)
     if not suppress_errors and ERROR is not None:
         json_data = to_json(response)
-        raise ERROR(json_data['resolve'], json_data['code'])
+        raise ERROR(json_data['resolve'], json_data['code'], response.headers['x-request-id'])
     else:
         return response
 


### PR DESCRIPTION
Add request ids to error objects

Example:

```
from plaid import Client
from plaid import errors as plaid_errors
from plaid.utils import json

client = Client(client_id='test_id', secret='test_secret')
account_type = 'bofa'

try:
  response = client.connect(account_type, {
    'username': 'plaid_test',
    'password': 'thisiswrong'
    })
  print response.headers['x-request-id']
except Exception as e:
    print e.requestId
```